### PR TITLE
Support basic authentication for SonarQube

### DIFF
--- a/sonar2csv/README.md
+++ b/sonar2csv/README.md
@@ -26,6 +26,11 @@ Write configuration about SonarQube to `config.toml`.
     "bugs",
     "violations"
   ]
+
+// only if your SonarQube needs user authentication
+[sonarqube.auth]
+  login = "admin"
+  password = "passwd"
 ```
 
 # Usage

--- a/sonar2csv/config.toml
+++ b/sonar2csv/config.toml
@@ -65,3 +65,7 @@
     "vulnerabilities",
     "wont_fix_issues"
   ]
+
+[sonarqube.auth]
+  login = ""
+  password = ""

--- a/sonar2csv/sonar2csv/http.go
+++ b/sonar2csv/sonar2csv/http.go
@@ -14,7 +14,12 @@ type SonarServer struct {
 	URL      *url.URL
 	Resource string
 	Metrics  []string
+	Auth struct{
+		Login string
+		Password string
+	}
 }
+
 
 func NewServer(c util.SonarSetting) (*SonarServer, error) {
 	u, err := url.Parse(c.URL)
@@ -26,6 +31,13 @@ func NewServer(c util.SonarSetting) (*SonarServer, error) {
 		URL:      u,
 		Resource: c.Resource,
 		Metrics:  c.Metrics,
+		Auth: struct{
+			Login string
+			Password string
+		}{
+			Login: c.Authentication.Login,
+			Password: c.Authentication.Password,
+		},
 	}, nil
 }
 
@@ -41,10 +53,14 @@ func (s *SonarServer) GetResources() (*http.Response, error) {
 
 func (s *SonarServer) Get() (*http.Response, error) {
 	log.Print("Request to ", s.URL.String())
-	resp, err := s.Client.Do(&http.Request{
-		Method: "GET",
-		URL:    s.URL,
-	})
+
+	req, err := http.NewRequest("GET", s.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(s.Auth.Login, s.Auth.Password)
+
+	resp, err := s.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/sonar2csv/util/conf.go
+++ b/sonar2csv/util/conf.go
@@ -15,6 +15,12 @@ type SonarSetting struct {
 	URL      string
 	Resource string
 	Metrics  []string
+	Authentication SonarAuthentication `toml:"auth"`
+}
+
+type SonarAuthentication struct {
+	Login string
+	Password string
 }
 
 type Files struct {


### PR DESCRIPTION
When requesting to SonarQube that requires user authentication, the following errors occured.

```
$ go run main.go
2018/02/13 16:24:58 Request to http://localhost:9000/api/resources?metrics=time%2Calert_status%2Cblocker_violations%2Cbugs%2Cclass_complexity%2Cclasses%2Ccode_smells%2Ccomment_lines%2Ccomment_lines_density%2Ccommit.id%2Ccomplexity%2Ccomplexity_in_classes%2Ccomplexity_in_functions%2Cconfirmed_issues%2Ccoverage%2Ccritical_violations%2Cdevelopment_cost%2Cdirectories%2Cduplicated_blocks%2Cduplicated_files%2Cduplicated_lines%2Cduplicated_lines_density%2Ceffort_to_reach_maintainability_rating_a%2Cfalse_positive_issues%2Cfile_complexity%2Cfile_complexity_distribution%2Cfiles%2Cfunction_complexity%2Cfunction_complexity_distribution%2Cfunctions%2Cinfo_violations%2Clast_commit_date%2Cline_coverage%2Clines%2Clines_to_cover%2Cmajor_violations%2Cminor_violations%2Cncloc%2Cncloc_language_distribution%2Copen_issues%2Cquality_gate_details%2Cquality_profiles%2Creliability_rating%2Creliability_remediation_effort%2Creopened_issues%2Csecurity_rating%2Csecurity_remediation_effort%2Cskipped_tests%2Csqale_debt_ratio%2Csqale_index%2Csqale_rating%2Cstatements%2Ctest_errors%2Ctest_execution_time%2Ctest_failures%2Ctest_success_density%2Ctests%2Cuncovered_lines%2Curl%2Cviolations%2Cvulnerabilities%2Cwont_fix_issues&resource=063285ca8e14
2018/02/13 16:24:58 401 Unauthorized
exit status 1
```

Need to support basic authentication for SonarQube.